### PR TITLE
Added villager_job_site.sc

### DIFF
--- a/villager_job_site.sc
+++ b/villager_job_site.sc
@@ -1,4 +1,4 @@
-import('math','distance');//Doesn't actually work until gnembon accepts https://github.com/gnembon/fabric-carpet/pull/289, till then just get fainter lines cos below resolves to null fro unknown func
+import('math','euclidean');
 
 __config() -> m( l('stay_loaded', 'true'),l('scope', 'global'));
 __on_player_uses_item(player, item_tuple, hand)->(
@@ -10,8 +10,8 @@ __on_player_uses_item(player, item_tuple, hand)->(
             pos=mem:'"minecraft:job_site"':'value':'pos'||mem:'"minecraft:job_site"':'pos'||null;
             if(!pos,return());
             l(x,y,z)=nbt(pos):'[]';
-            particle_line('happy_villager',pos(entity),pos(player),if(distance(pos(entity),pos(player))<2,0.1,1));
-            particle_line('happy_villager',pos(entity),l(x+0.5,y+0.5,z+0.5),if(distance(pos(entity),l(x+0.5,y+0.5,z+0.5))<2,0.1,1));
+            particle_line('happy_villager',pos(entity),pos(player),if(euclidean(pos(entity),pos(player))<2,0.1,1));
+            particle_line('happy_villager',pos(entity),l(x+0.5,y+0.5,z+0.5),if(euclidean(pos(entity),l(x+0.5,y+0.5,z+0.5))<2,0.1,1));
         ),
     )
 )

--- a/villager_job_site.sc
+++ b/villager_job_site.sc
@@ -1,0 +1,17 @@
+import('math','distance');//Doesn't actually work until gnembon accepts https://github.com/gnembon/fabric-carpet/pull/289, till then just get fainter lines cos below resolves to null fro unknown func
+
+__config() -> m( l('stay_loaded', 'true'),l('scope', 'global'));
+__on_player_uses_item(player, item_tuple, hand)->(
+    if(item_tuple:0=='blaze_rod',
+        entity=query(player,'trace',20,'entities')||null;
+        if(type(entity)=='entity'&&entity~'type'=='villager',
+            brain= entity~'nbt':'Brain';
+            mem=brain:'memories';
+            pos=mem:'"minecraft:job_site"':'value':'pos'||mem:'"minecraft:job_site"':'pos'||null;
+            if(!pos,return());
+            l(x,y,z)=nbt(pos):'[]';
+            particle_line('happy_villager',pos(entity),pos(player),if(distance(pos(entity),pos(player))<2,0.1,1));
+            particle_line('happy_villager',pos(entity),l(x+0.5,y+0.5,z+0.5),if(distance(pos(entity),l(x+0.5,y+0.5,z+0.5))<2,0.1,1));
+        ),
+    )
+)


### PR DESCRIPTION
Right clicking in direction of villager with blaze rod will show its workstation.
Also a line of particles from you to villager, in case you didn't understand which villager it was you clicked on.
I found this would be a good platform to share this stuff to an appreciative audience who would use it.
It sorta depends on https://github.com/gnembon/fabric-carpet/pull/289 to be accepted, but till then, it shouldn't be a big deal, just less particles.